### PR TITLE
Fix embeddings model name in settings.yaml

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -31,7 +31,7 @@ embeddings:
   llm:
     api_key: ${GRAPHRAG_API_KEY}
     type: openai_embedding # or azure_openai_embedding
-    model: nomic_embed_text
+    model: nomic-embed-text
     api_base: http://localhost:11434/api
     # api_version: 2024-02-15-preview
     # organization: <organization_id>


### PR DESCRIPTION


## Description

The embeddings model in the default settings.yaml in incorrectly specified as "nomic_embed_text" - this causes the quickstart instructions in the README to fail.  

The correct name for the ollama embeddings model is "nomic-embed-text"


## Related Issues

Following the instructions in the readme results in a failed run, and this message in the logs:

```
  File "/opt/homebrew/anaconda3/envs/graphrag-ollama-local/lib/python3.10/site-packages/ollama/_client.py", line 280, in embeddings
    return self._request(
  File "/opt/homebrew/anaconda3/envs/graphrag-ollama-local/lib/python3.10/site-packages/ollama/_client.py", line 74, in _request
    raise ResponseError(e.response.text, e.response.status_code) from None
ollama._types.ResponseError: model "nomic_embed_text" not found, try pulling it first
18:07:48,8 graphrag.index.reporting.file_workflow_callbacks INFO Error running pipeline! details=None
```

## Proposed Changes

Swaps underscores for dashes to make the name correct in the default config.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes
